### PR TITLE
Bundle Install before Build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,8 @@ cd ..
 
 # rebuild the docs
 cd bogl-docs/
+# ensure to run a quick bundle install, in case new deps are present
+bundle install
 bundle exec jekyll build
 sudo rsync -r _site/ /var/www/html/bogl/docs/
 cd ..


### PR DESCRIPTION
I made a note before about having `bundle install` before the `bundle ... build` phase of the setup.sh script over our last video call. However, after looking at it again, it makes much more sense to have it in the build.sh script directly. Then we can handle proper installing during the setup process *and* during general operation, in case an additional package is added.